### PR TITLE
Add Blackman-Harris window function and create go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/mjibson/go-dsp
+
+go 1.21.1

--- a/window/window.go
+++ b/window/window.go
@@ -150,3 +150,22 @@ func Blackman(L int) []float64 {
 	}
 	return r
 }
+
+// BlackmanHarris returns an L-point Blackman-Harris window
+// Reference: https://www.mathworks.com/help/signal/ref/blackmanharris.html
+func BlackmanHarris(L int) []float64 {
+	r := make([]float64, L)
+	if L == 1 {
+		r[0] = 1
+	} else {
+		N := L - 1
+		for n := 0; n <= N; n++ {
+			const term0 = 0.35875
+			term1 := -0.48829 * math.Cos(2*math.Pi*float64(n)/float64(N))
+			term2 := 0.14128 * math.Cos(4*math.Pi*float64(n)/float64(N))
+			term3 := -0.01168 * math.Cos(6*math.Pi*float64(n)/float64(N))
+			r[n] = term0 + term1 + term2 + term3
+		}
+	}
+	return r
+}

--- a/window/window_test.go
+++ b/window/window_test.go
@@ -23,17 +23,19 @@ import (
 )
 
 type windowTest struct {
-	in       int
-	hamming  []float64
-	hann     []float64
-	bartlett []float64
-	flatTop  []float64
-	blackman []float64
+	in				int
+	hamming  		[]float64
+	hann     		[]float64
+	bartlett 		[]float64
+	flatTop  		[]float64
+	blackman 		[]float64
+	blackmanHarris	[]float64
 }
 
 var windowTests = []windowTest{
 	{
 		1,
+		[]float64{1},
 		[]float64{1},
 		[]float64{1},
 		[]float64{1},
@@ -47,6 +49,7 @@ var windowTests = []windowTest{
 		[]float64{0, 0.5, 1, 0.5, 0},
 		[]float64{-0.0004210510000000013, -0.05473684000000003, 1, -0.05473684000000003, -0.0004210510000000013},
 		[]float64{0, 0.34, 1, 0.34, 0},
+		[]float64{0.00006, 0.21747, 1, 0.21747, 0.00006},
 	},
 	{
 		10,
@@ -55,6 +58,7 @@ var windowTests = []windowTest{
 		[]float64{0, 0.222222222222222, 0.444444444444444, 0.666666666666667, 0.888888888888889, 0.888888888888889, 0.666666666666667, 0.444444444444444, 0.222222222222222, 0},
 		[]float64{-0.000421051000000, -0.020172031509486, -0.070199042063189, 0.198210530000000, 0.862476344072674, 0.862476344072674, 0.198210530000000, -0.070199042063189, -0.020172031509486, -0.000421051000000},
 		[]float64{0, 0.0508696327, 0.258000502, 0.63, 0.951129866, 0.951129866, 0.63, 0.258000502, 0.0508696327, 0},
+		[]float64{0.00006, 0.01507, 0.14704, 0.52057, 0.93166, 0.93166, 0.52057, 0.14704, 0.01507, 0.00006},
 	},
 }
 
@@ -89,6 +93,11 @@ func TestWindowFunctions(t *testing.T) {
 		o = Blackman(v.in)
 		if !dsputils.PrettyClose(o, v.blackman) {
 			t.Error("blackman error\ninput:", v.in, "\noutput:", o, "\nexpected:", v.blackman)
+		}
+
+		o = BlackmanHarris(v.in)
+		if !dsputils.PrettyClose(o, v.blackmanHarris) {
+			t.Error("blackmanHarris error\ninput:", v.in, "\noutput:", o, "\nexpected:", v.blackmanHarris)
 		}
 	}
 }


### PR DESCRIPTION
I added a function for a Blackman-Harris window to the `window` package as well as the relevant tests. I ran into an issue using `go test` to run `window_test.go`, so I ran `go mod init && go mod tidy` in the root directory to add a `go.mod` file. 

Currently `go test` will fail for a 10-point Blackman-Harris window because I didn't add enough digits to the test case in `window_test.go`, and I'm not sure how to get more precision from Matlab at the moment. However, I implemented the function exactly as it appears in [https://www.mathworks.com/help/signal/ref/blackmanharris.html](https://www.mathworks.com/help/signal/ref/blackmanharris.html) so I'm confident it's doing the correct calculations. 